### PR TITLE
Switch to using ephemeral URLSessionConfigurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+build/

--- a/Sources/SwiftQuests/Request.swift
+++ b/Sources/SwiftQuests/Request.swift
@@ -69,7 +69,7 @@ open class Request: AbstractRequest {
   /// The request `URLSession`.
   ///
   /// Defaults to a session with a `default` `URLSessionConfiguration` unless otherwise specified.
-  public var session = URLSession(configuration: .default)
+  public var session = URLSession(configuration: .ephemeral)
 
   /// The wrapped `URLRequest` object.
   public var urlRequest: URLRequest!
@@ -138,9 +138,10 @@ open class Request: AbstractRequest {
     }
 
     if let credential = credential {
-      URLCredentialStorage.shared.set(credential,
-                                      for: configuration.protectionSpace,
-                                      task: task)
+      URLCredentialStorage.shared.set(
+        credential,
+        for: configuration.protectionSpace,
+        task: task)
     }
 
     task.resume()


### PR DESCRIPTION
Potentially fix CFNetwork memory leak issues.

Changes proposed in this pull request:
- Switch to using ephemeral URLSessionConfigurations by default.
